### PR TITLE
Dockerfile - Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12-alpine
 
 WORKDIR /api
 COPY package*.json ./


### PR DESCRIPTION
# Summary

Proposing using a base image based on Alpine Linux to reduce the end Docker image's size:

> Alpine Linux is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.

> This variant is highly recommended when final image size being as small as possible is desired.

_source https://hub.docker.com/_/node_