### PR TITLE
Create Docker image workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag wikivent:$(date +%s)


### PR DESCRIPTION
# Summary

Docker equivalent of https://github.com/supernoir/wikivent/pull/4 - creating a CI workflow for building a Docker image. Can push to Docker Hub using https://github.com/marketplace/actions/build-and-push-docker-images#example-usage